### PR TITLE
Add interactive highlight puzzle to developer section

### DIFF
--- a/zackhagan/src/components/DeveloperSpotlight.jsx
+++ b/zackhagan/src/components/DeveloperSpotlight.jsx
@@ -1,7 +1,7 @@
+import { useMemo, useState } from 'react'
 import {
   FiExternalLink,
   FiGithub,
-  FiLayers,
   FiMonitor,
   FiZap,
   FiGrid,
@@ -104,6 +104,36 @@ const projects = [
 ]
 
 function DeveloperSpotlight() {
+  const [flippedCards, setFlippedCards] = useState(new Set())
+  const puzzleImage = '/assets/images/zackPortfolio.jpg'
+  const gridColumns = 5
+
+  const puzzleHighlights = useMemo(
+    () =>
+      highlights.map((item, index) => ({
+        ...item,
+        col: index % gridColumns,
+        row: Math.floor(index / gridColumns)
+      })),
+    [gridColumns]
+  )
+
+  const gridRows = useMemo(() => Math.ceil(puzzleHighlights.length / gridColumns), [puzzleHighlights.length, gridColumns])
+
+  const handleFlip = (title) => {
+    setFlippedCards((prev) => {
+      const next = new Set(prev)
+      if (next.has(title)) {
+        next.delete(title)
+      } else {
+        next.add(title)
+      }
+      return next
+    })
+  }
+
+  const allRevealed = flippedCards.size === puzzleHighlights.length
+
   return (
     <div className="dev-section">
       <div className="dev-hero">
@@ -122,14 +152,43 @@ function DeveloperSpotlight() {
         </a>
       </div>
       <div className="dev-right">
+        <div className="puzzle-status">
+          <p className="muted">
+            Flip each highlight tile to reveal a fragment of the full portrait. {flippedCards.size}/
+            {puzzleHighlights.length} revealed{allRevealed ? ' — full image unlocked!' : ''}
+          </p>
+        </div>
         <div className="dev-grid">
-          {highlights.map((item) => (
-            <article className="glass-card" key={item.title}>
-              <div className="icon-circle">{item.icon}</div>
-              <h4>{item.title}</h4>
-              <p className="muted">{item.description}</p>
-            </article>
-          ))}
+          {puzzleHighlights.map((item) => {
+            const isFlipped = flippedCards.has(item.title)
+            return (
+              <article
+                className={`glass-card flip-card ${isFlipped ? 'is-flipped' : ''}`}
+                key={item.title}
+                onClick={() => handleFlip(item.title)}
+              >
+                <div className="flip-inner">
+                  <div className="card-face card-front">
+                    <div className="icon-circle">{item.icon}</div>
+                    <h4>{item.title}</h4>
+                    <p className="muted">{item.description}</p>
+                  </div>
+                  <div
+                    className="card-face card-back puzzle-piece"
+                    style={{
+                      '--tile-col': item.col,
+                      '--tile-row': item.row,
+                      '--tile-cols': gridColumns,
+                      '--tile-rows': gridRows,
+                      backgroundImage: `url(${puzzleImage})`
+                    }}
+                  >
+                    <span className="puzzle-overlay">{item.title}</span>
+                  </div>
+                </div>
+              </article>
+            )
+          })}
         </div>
 
         <div className="dev-projects">

--- a/zackhagan/src/index.css
+++ b/zackhagan/src/index.css
@@ -264,6 +264,12 @@ a {
   grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
   gap: 12px;
 }
+.puzzle-status {
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px dashed var(--border);
+  background: rgba(255, 255, 255, 0.04);
+}
 
 .dev-right {
   display: grid;
@@ -276,6 +282,78 @@ a {
   border: 1px solid var(--border);
   background: rgba(12, 14, 20, 0.78);
   box-shadow: 0 16px 28px rgba(0, 0, 0, 0.3);
+}
+
+.glass-card.flip-card {
+  padding: 0;
+  cursor: pointer;
+  perspective: 1200px;
+  overflow: hidden;
+}
+
+.flip-inner {
+  position: relative;
+  height: 100%;
+  transition: transform 0.7s ease;
+  transform-style: preserve-3d;
+}
+
+.flip-card.is-flipped .flip-inner {
+  transform: rotateY(180deg);
+}
+
+.card-face {
+  position: absolute;
+  inset: 0;
+  padding: 14px;
+  display: grid;
+  gap: 10px;
+  backface-visibility: hidden;
+  border-radius: 14px;
+}
+
+.card-front {
+  background: rgba(12, 14, 20, 0.82);
+  border: 1px solid var(--border);
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.3);
+}
+
+.card-back {
+  transform: rotateY(180deg);
+  background-size: calc(var(--tile-cols, 4) * 100%) calc(var(--tile-rows, 3) * 100%);
+  background-repeat: no-repeat;
+  background-position:
+    calc(var(--tile-col) * (-100% / var(--tile-cols, 4)))
+    calc(var(--tile-row) * (-100% / var(--tile-rows, 3)));
+  border: 1px solid var(--border);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
+}
+
+.puzzle-piece {
+  align-content: end;
+  color: #e9ecf5;
+  text-shadow: 0 8px 18px rgba(0, 0, 0, 0.5);
+  position: relative;
+  overflow: hidden;
+}
+
+.puzzle-piece::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(0, 0, 0, 0.24), rgba(12, 14, 20, 0.36));
+}
+
+.puzzle-overlay {
+  position: relative;
+  z-index: 1;
+  font-weight: 700;
+  font-size: 14px;
+  background: rgba(0, 0, 0, 0.38);
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  width: fit-content;
 }
 
 .icon-circle {


### PR DESCRIPTION
## Summary
- keep the original highlight lineup while enabling flip-card puzzle interactions
- set puzzle grid sizing from card count to keep the portrait aligned with the existing highlights
- refine background sizing variables so each flipped tile reveals its correct portion of the image

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e8af50a8832aa9997bb43bbac088)